### PR TITLE
Refactor settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
-# forest-lite
-Minimal implementation of FOREST
+# FOREST-lite
+
+Minimal implementation of FOREST. It uses FastAPI to expose data via
+a REST API. The client application uses Redux and React to manage
+state and components. For visualisation, BokehJS and Turf.js have
+been chosen for their composability and ease-of-use.
+
+## Getting started
+
+To start the FastAPI server run a command similar to the following
+
+```sh
+CONFIG_FILE=config.yaml python ${REPO_DIR}/lite/main.py --port 8080
+```
+
+## Configuration
+
+The specification for config files has not yet been formalised but
+for now it takes lessons learned from the FOREST project
+
+```yaml
+datasets:
+  - label: EIDA50
+    driver:
+      name: eida50
+      settings:
+        pattern: path/to/EIDA50_*.nc
+```
+
+**Note:** This schema may change in future releases
+

--- a/lite/config.py
+++ b/lite/config.py
@@ -1,0 +1,5 @@
+from pydantic import BaseSettings
+
+
+class Settings(BaseSettings):
+    config_file: str

--- a/lite/main.py
+++ b/lite/main.py
@@ -32,6 +32,7 @@ def get_settings():
     return config.Settings()
 
 
+@lru_cache
 def load_config(path):
     with open(path) as stream:
         data = yaml.safe_load(stream)

--- a/lite/test_settings.py
+++ b/lite/test_settings.py
@@ -1,0 +1,35 @@
+import yaml
+from fastapi.testclient import TestClient
+import main, config
+
+
+client = TestClient(main.app)
+
+
+def get_settings(config_file):
+    def wrapper():
+        return config.Settings(config_file=config_file)
+    return wrapper
+
+
+def test_datasets_endpoint(tmpdir):
+
+    # Prepare fake config.yaml
+    path = str(tmpdir / "test-conf.yaml")
+    data = {
+        "datasets": [
+            {"label": "Foo"},
+            {"label": "Bar"}
+        ]
+    }
+    with open(path, "w") as stream:
+        yaml.dump(data, stream)
+
+    # Patch main.get_settings
+    main.app.dependency_overrides[main.get_settings] = get_settings(path)
+
+    # GET /datasets endpoint
+    response = client.get("/datasets")
+    assert response.json() == {
+        "names": ["Bar", "Foo"]
+    }


### PR DESCRIPTION
- Remove `CONFIG` global variable
- Add unit test to patch `main.get_settings` to substitute example config yaml files
- Remove positional command line argument in favour of `CONFIG_FILE` environment variable