### PR TITLE
Nearcast driver port

### DIFF
--- a/forest_lite/examples/nearcast-driver.yaml
+++ b/forest_lite/examples/nearcast-driver.yaml
@@ -1,0 +1,6 @@
+datasets:
+  - label: Nearcast
+    driver:
+      name: nearcast
+      settings:
+        pattern: *.grib

--- a/forest_lite/examples/nearcast-driver.yaml
+++ b/forest_lite/examples/nearcast-driver.yaml
@@ -1,5 +1,11 @@
 datasets:
   - label: Nearcast
+    palettes:
+      default:
+        name: Viridis
+        number: 256
+        low: 1
+        high: 6
     driver:
       name: nearcast
       settings:

--- a/forest_lite/examples/nearcast-driver.yaml
+++ b/forest_lite/examples/nearcast-driver.yaml
@@ -4,8 +4,43 @@ datasets:
       default:
         name: Viridis
         number: 256
-        low: 1
-        high: 6
+        low: 200
+        high: 400
+      Precipitable water:
+        name: Oranges
+        number: 256
+        low: 0
+        high: 20
+      U component of wind:
+        colors:
+          - '#053061'
+          - '#2166ac'
+          - '#4393c3'
+          - '#92c5de'
+          - '#d1e5f0'
+          - 'rgba(0,0,0,0)'
+          - '#fddbc7'
+          - '#f4a582'
+          - '#d6604d'
+          - '#b2182b'
+          - '#67001f'
+        low: '-20'
+        high: 20
+      V component of wind:
+        colors:
+          - '#053061'
+          - '#2166ac'
+          - '#4393c3'
+          - '#92c5de'
+          - '#d1e5f0'
+          - 'rgba(0,0,0,0)'
+          - '#fddbc7'
+          - '#f4a582'
+          - '#d6604d'
+          - '#b2182b'
+          - '#67001f'
+        low: '-20'
+        high: 20
     driver:
       name: nearcast
       settings:

--- a/forest_lite/examples/nearcast-driver.yaml
+++ b/forest_lite/examples/nearcast-driver.yaml
@@ -3,4 +3,4 @@ datasets:
     driver:
       name: nearcast
       settings:
-        pattern: *.grib
+        pattern: ${NEARCAST_DIR}/*.GRIB2

--- a/forest_lite/server/drivers/__init__.py
+++ b/forest_lite/server/drivers/__init__.py
@@ -8,4 +8,10 @@ def from_spec(spec):
         mod_name, obj_name = spec.name.split(":")
         module = import_module(mod_name)
         return getattr(module, obj_name)
-    return module.Driver(spec.name, spec.settings)
+    try:
+        return module.Driver(spec.name, spec.settings)
+    except AttributeError:
+        # TODO: Mechanism to configure driver(s)
+        driver = module.driver
+        driver.settings = spec.settings
+        return driver

--- a/forest_lite/server/drivers/__init__.py
+++ b/forest_lite/server/drivers/__init__.py
@@ -4,10 +4,13 @@ from importlib import import_module
 def from_spec(spec):
     try:
         module = import_module(f"forest_lite.server.drivers.{spec.name}")
-    except ModuleNotFoundError:
-        mod_name, obj_name = spec.name.split(":")
-        module = import_module(mod_name)
-        return getattr(module, obj_name)
+    except ModuleNotFoundError as e:
+        if spec.name in e.msg:
+            mod_name, obj_name = spec.name.split(":")
+            module = import_module(mod_name)
+            return getattr(module, obj_name)
+        else:
+            raise e
     try:
         return module.Driver(spec.name, spec.settings)
     except AttributeError:

--- a/forest_lite/server/drivers/base.py
+++ b/forest_lite/server/drivers/base.py
@@ -1,3 +1,4 @@
+import numpy as np
 from forest_lite.server.lib import core
 from forest_lite.server.inject import Injectable
 
@@ -13,9 +14,10 @@ class BaseDriver(Injectable):
 
     def tilable(self, timestamp_ms, data_var):
         return {
-            "longitude": [],
-            "latitude": [],
-            "values": [],
+            "longitude": np.array([], dtype="f"),
+            "latitude": np.array([], dtype="f"),
+            "values": np.empty((0, 0), dtype="f"),
+            "units": ""
         }
 
     def description(self):

--- a/forest_lite/server/drivers/base.py
+++ b/forest_lite/server/drivers/base.py
@@ -1,5 +1,22 @@
+from forest_lite.server.lib import core
 from forest_lite.server.inject import Injectable
 
 
 class BaseDriver(Injectable):
-    pass
+    """Extendable interface"""
+    def get_times(self, limit=None):
+        return []
+
+    def data_tile(self, data_var, timestamp_ms, z, x, y):
+        tilable = self.tilable(data_var=data_var, timestamp_ms=timestamp_ms)
+        return core._tile(tilable, z, x, y)
+
+    def tilable(self, timestamp_ms, data_var):
+        return {
+            "longitude": [],
+            "latitude": [],
+            "values": [],
+        }
+
+    def description(self):
+        return {}

--- a/forest_lite/server/drivers/base.py
+++ b/forest_lite/server/drivers/base.py
@@ -1,0 +1,5 @@
+from forest_lite.server.inject import Injectable
+
+
+class BaseDriver(Injectable):
+    pass

--- a/forest_lite/server/drivers/nearcast.py
+++ b/forest_lite/server/drivers/nearcast.py
@@ -1,4 +1,12 @@
+"""
+Nearcast driver
+"""
 from forest_lite.server.drivers.base import BaseDriver
 
 
 driver = BaseDriver()
+
+
+@driver.get_times
+def nearcast_times(limits=None):
+    return []

--- a/forest_lite/server/drivers/nearcast.py
+++ b/forest_lite/server/drivers/nearcast.py
@@ -1,12 +1,29 @@
 """
 Nearcast driver
 """
+import os
+import glob
+import string
+from forest_lite.server.inject import Use
 from forest_lite.server.drivers.base import BaseDriver
+from pydantic import BaseModel
+
+
+class Settings(BaseModel):
+    pattern: str
 
 
 driver = BaseDriver()
 
 
-@driver.get_times
-def nearcast_times(limits=None):
+def get_file_names():
+    """Search disk for Nearcast files"""
+    pattern = Settings(**driver.settings).pattern
+    wildcard = string.Template(pattern).substitute(**os.environ)
+    return sorted(glob.glob(wildcard))
+
+
+@driver.override("get_times")
+def nearcast_times(limits=None, file_names=Use(get_file_names)):
+    print(file_names)
     return []

--- a/forest_lite/server/drivers/nearcast.py
+++ b/forest_lite/server/drivers/nearcast.py
@@ -1,0 +1,4 @@
+from forest_lite.server.drivers.base import BaseDriver
+
+
+driver = BaseDriver()

--- a/forest_lite/server/drivers/nearcast.py
+++ b/forest_lite/server/drivers/nearcast.py
@@ -63,13 +63,13 @@ def get_data_vars(path):
 
 @driver.override("tilable")
 def nearcast_tilable(data_var, timestamp_ms, file_names=Use(get_file_names)):
-    valid_time = dt.datetime.fromtimestamp(timestamp_ms / 1000.)
     path = sorted(file_names)[-1]
-    pressure = 1000
-    return get_grib2_data(path, valid_time, data_var, pressure)
+    return get_grib2_data(path, timestamp_ms, data_var)
 
 
-def get_grib2_data(path, valid_time, variable, pressure):
+@lru_cache
+def get_grib2_data(path, timestamp_ms, variable):
+    valid_time = dt.datetime.fromtimestamp(timestamp_ms / 1000.)
     cache = {}
     messages = pg.index(path,
                         "name",

--- a/forest_lite/server/drivers/nearcast.py
+++ b/forest_lite/server/drivers/nearcast.py
@@ -1,8 +1,10 @@
 """
 Nearcast driver
 """
+import datetime as dt
 import os
 import glob
+import re
 import string
 from forest_lite.server.inject import Use
 from forest_lite.server.drivers.base import BaseDriver
@@ -23,7 +25,68 @@ def get_file_names():
     return sorted(glob.glob(wildcard))
 
 
+def get_times():
+    return sorted(parse_date(path) for path in get_file_names())
+
+
+def parse_date(path):
+    """Parse datetime from file name"""
+    groups = re.search("[0-9]{8}_[0-9]{4}", os.path.basename(path))
+    if groups is not None:
+        return dt.datetime.strptime(groups[0], "%Y%m%d_%H%M")
+
+
 @driver.override("get_times")
-def nearcast_times(limits=None, file_names=Use(get_file_names)):
-    print(file_names)
-    return []
+def nearcast_times(limits=None, times=Use(get_times)):
+    return times[-limits:]
+
+
+@driver.override("description")
+def nearcast_description():
+    return {
+        "data_vars": {
+            "variable": {}
+        }
+    }
+
+
+@driver.override("tilable")
+def nearcast_tilable(data_var, timestamp_ms):
+    print(data_var, timestamp_ms)
+    return {
+        "longitude": [0, 1, 2],
+        "latitude": [0, 1, 2],
+        "values": [
+            [0, 1, 2],
+            [2, 3 ,4],
+            [3, 4, 5]
+        ],
+        "units": ""
+    }
+
+
+def get_grib2_data(path, valid_time, variable, pressure):
+    cache = {}
+
+    validTime = dt.datetime.strptime(str(valid_time), "%Y-%m-%d %H:%M:%S")
+    vTime = "{0:d}{1:02d}".format(validTime.hour, validTime.minute)
+
+    messages = pg.index(path, "name", "scaledValueOfFirstFixedSurface", "validityTime")
+    if len(path) > 0:
+        field = messages.select(name=variable, scaledValueOfFirstFixedSurface=int(pressure), validityTime=vTime)[0]
+        cache["longitude"] = field.latlons()[1][0,:]
+        cache["latitude"] = field.latlons()[0][:,0]
+        cache["data"] = field.values
+        cache["units"] = field.units
+        cache["name"] = field.name
+        cache["valid"] = "{0:02d}:{1:02d} UTC".format(validTime.hour, validTime.minute)
+        cache["initial"] = "blah"
+        scaledLowerLevel = float(field.scaledValueOfFirstFixedSurface)
+        scaleFactorLowerLevel = float(field.scaleFactorOfFirstFixedSurface)
+        lowerSigmaLevel = str(round(scaledLowerLevel * 10**-scaleFactorLowerLevel, 2))
+        scaledUpperLevel = float(field.scaledValueOfSecondFixedSurface)
+        scaleFactorUpperLevel = float(field.scaleFactorOfSecondFixedSurface)
+        upperSigmaLevel = str(round(scaledUpperLevel * 10**-scaleFactorUpperLevel, 2))
+        cache['layer'] = lowerSigmaLevel+"-"+upperSigmaLevel
+    messages.close()
+    return cache

--- a/forest_lite/server/lib/tiling.py
+++ b/forest_lite/server/lib/tiling.py
@@ -54,6 +54,10 @@ def tile_extents(zxy):
 
 def web_mercator(lons, lats):
     """Similar to forest.geo.web_mercator but preserves array shape"""
+    if isinstance(lons, list):
+        lons = np.asarray(lons)
+    if isinstance(lats, list):
+        lats = np.asarray(lats)
     if (lons.ndim == 1):
         gx, _ = geo.web_mercator(
             lons,

--- a/forest_lite/test/test_drivers_base.py
+++ b/forest_lite/test/test_drivers_base.py
@@ -1,0 +1,12 @@
+from forest_lite.server.drivers.base import BaseDriver
+
+
+def test_base_driver_api():
+    driver = BaseDriver()
+    assert driver.get_times() == []
+    assert driver.tilable(timestamp_ms=None, data_var=None) == {
+        "latitude": [],
+        "longitude": [],
+        "values": []
+    }
+    assert driver.description() == {}

--- a/forest_lite/test/test_drivers_nearcast.py
+++ b/forest_lite/test/test_drivers_nearcast.py
@@ -1,0 +1,7 @@
+from forest_lite.server.drivers.nearcast import driver
+from forest_lite.server.drivers.base import BaseDriver
+
+
+
+def test_importable():
+    assert isinstance(driver, BaseDriver)


### PR DESCRIPTION
- Re-use `forest.drivers.nearcast` to power a FOREST Lite tiled image