### PR TITLE
Use tile_key to simplify update

### DIFF
--- a/forest_lite/client/src/tiling.js
+++ b/forest_lite/client/src/tiling.js
@@ -39,7 +39,15 @@ export const renderTiles = source => urls => {
     Promise.all(promises)
         .then(tiles => tiles.reduce(imageReducer, emptyImage))
         .then(data => {
-            source.data = data
+            // Check if image positions can be re-used
+            if (JSON.stringify(data.tile_key) === JSON.stringify(source.data.tile_key)) {
+                for (let i=0; i<data.image.length; i++) {
+                    source.data.image[i] = data.image[i]
+                }
+            } else {
+                // Pan/zoom cases
+                source.data = data
+            }
             source.change.emit()
         })
 }

--- a/forest_lite/server/lib/core.py
+++ b/forest_lite/server/lib/core.py
@@ -76,7 +76,8 @@ def _tile(tilable, z, x, y):
                             values, zxy,
                             tile_size=TILE_SIZE)
     data.update({
-        "units": [units]
+        "units": [units],
+        "tile_key": [[x, y, z]]
     })
     return data
 


### PR DESCRIPTION
- Without an optimized animation glyph renderer updates can be performed quickly if tile locations do not change ~100ms instead of 2 seconds