### PR TITLE
Remove eida50 specialised driver name

### DIFF
--- a/forest_lite/server/drivers/eida50.py
+++ b/forest_lite/server/drivers/eida50.py
@@ -1,6 +1,0 @@
-import warnings
-from forest_lite.server.drivers.xarray_h5netcdf import driver
-
-
-warnings.warn("'eida50' driver is deprecated please use 'xarray_h5netcdf'",
-              DeprecationWarning)

--- a/forest_lite/test/test_drivers_xarray_h5netcdf.py
+++ b/forest_lite/test/test_drivers_xarray_h5netcdf.py
@@ -1,5 +1,5 @@
 from forest_lite.test.helpers import sample_h5netcdf_dim0
-from forest_lite.server.drivers import eida50
+from forest_lite.server.drivers import xarray_h5netcdf
 import pytest
 
 

--- a/forest_lite/test/test_endpoints.py
+++ b/forest_lite/test/test_endpoints.py
@@ -15,7 +15,7 @@ def sample_config(netcdf_path):
             {
                 "label": "dataset-0",
                 "driver": {
-                    "name": "eida50",
+                    "name": "xarray_h5netcdf",
                     "settings": {
                         "pattern": netcdf_path
                     }
@@ -68,7 +68,7 @@ def test_dataset_data_vars(tmpdir):
             {
                 "label": "Label",
                 "driver": {
-                    "name": "eida50",
+                    "name": "xarray_h5netcdf",
                     "settings": {
                         "pattern": netcdf_path,
                         "data_vars": ["air_temperature"]


### PR DESCRIPTION
- `xarray_h5netcdf` is the general purpose driver that was initially developed to read EIDA50 satellite feed