### PR TITLE
Add functools.wraps to document driver methods

### DIFF
--- a/forest_lite/server/inject.py
+++ b/forest_lite/server/inject.py
@@ -12,6 +12,7 @@ It does not prevent users from extending drivers via
 traditional approaches, e.g. class inheritance.
 
 """
+from functools import wraps
 from inspect import signature
 
 
@@ -39,6 +40,7 @@ class Injectable:
 
 
 def solve_dependencies(fn):
+    @wraps(fn)
     def wrapper(*args, **kwargs):
         deps = {}
         for key, param in signature(fn).parameters.items():


### PR DESCRIPTION
- Makes working with drivers interactively much better as `driver.method??` in ipython shows the correct source code