### PR TITLE
Batch coastline http requests into tiles

### DIFF
--- a/forest_lite/client/src/elm-app/src/BoundingBox.elm
+++ b/forest_lite/client/src/elm-app/src/BoundingBox.elm
@@ -1,4 +1,6 @@
-module BoundingBox exposing (BoundingBox)
+module BoundingBox exposing (BoundingBox, encode)
+
+import Json.Encode
 
 
 type alias BoundingBox =
@@ -7,3 +9,13 @@ type alias BoundingBox =
     , minlat : Float
     , maxlat : Float
     }
+
+
+encode : BoundingBox -> Json.Encode.Value
+encode box =
+    Json.Encode.object
+        [ ( "minlon", Json.Encode.float box.minlon )
+        , ( "maxlon", Json.Encode.float box.maxlon )
+        , ( "minlat", Json.Encode.float box.minlat )
+        , ( "maxlat", Json.Encode.float box.maxlat )
+        ]

--- a/forest_lite/client/src/elm-app/src/BoundingBox.elm
+++ b/forest_lite/client/src/elm-app/src/BoundingBox.elm
@@ -1,0 +1,9 @@
+module BoundingBox exposing (BoundingBox)
+
+
+type alias BoundingBox =
+    { minlon : Float
+    , maxlon : Float
+    , minlat : Float
+    , maxlat : Float
+    }

--- a/forest_lite/client/src/elm-app/src/Main.elm
+++ b/forest_lite/client/src/elm-app/src/Main.elm
@@ -199,7 +199,8 @@ type alias Model =
     , limits : Limits
     , collapsed : Dict String Bool
     , zoom_level : Maybe ZoomLevel
-    , tiles : List ZXY.XY
+    , xys : List XY
+    , quadkeys : List Quadkey
     }
 
 
@@ -390,7 +391,8 @@ init flags =
             , collapsed =
                 Dict.empty
             , zoom_level = Nothing
-            , tiles = []
+            , xys = []
+            , quadkeys = []
             }
     in
     case Json.Decode.decodeValue flagsDecoder flags of
@@ -1035,6 +1037,9 @@ updateAction model action =
                 xys =
                     MapExtent.tiles zoom_level viewport
 
+                quadkeys =
+                    List.map (\xy -> Quadkey.fromXY zoom_level xy) xys
+
                 cmd =
                     Cmd.batch
                         (List.map
@@ -1074,7 +1079,8 @@ updateAction model action =
             in
             ( { model
                 | zoom_level = Just zoom_level
-                , tiles = xys
+                , xys = xys
+                , quadkeys = quadkeys
               }
             , cmd
             )
@@ -1408,7 +1414,8 @@ viewLayerMenu model =
                             , viewCoastlineCheckbox model.coastlines
                             , viewCoastlineColorPicker model.coastlines_color
                             , viewZoomLevel model.zoom_level
-                            , viewTiles model.tiles
+                            , viewXYs model.xys
+                            , viewQuadkeys model.quadkeys
                             ]
                     , onClick = ExpandCollapse DisplayMenu
                     }
@@ -1446,8 +1453,8 @@ viewZoomLevel zoom_level =
             div [] [ text "Zoom level not set" ]
 
 
-viewTiles : List ZXY.XY -> Html Msg
-viewTiles tiles =
+viewXYs : List XY -> Html Msg
+viewXYs xys =
     div
         [ style "margin-left" "0.5em"
         , style "margin-top" "0.5em"
@@ -1458,9 +1465,28 @@ viewTiles tiles =
                 (\t ->
                     li
                         []
-                        [ text (MapExtent.xyToString t) ]
+                        [ text (ZXY.xyToString t) ]
                 )
-                tiles
+                xys
+            )
+        ]
+
+
+viewQuadkeys : List Quadkey -> Html Msg
+viewQuadkeys quadkeys =
+    div
+        [ style "margin-left" "0.5em"
+        , style "margin-top" "0.5em"
+        ]
+        [ div [] [ text "Tiles:" ]
+        , ul []
+            (List.map
+                (\t ->
+                    li
+                        []
+                        [ text (Quadkey.toString t) ]
+                )
+                quadkeys
             )
         ]
 

--- a/forest_lite/client/src/elm-app/src/Main.elm
+++ b/forest_lite/client/src/elm-app/src/Main.elm
@@ -1032,46 +1032,45 @@ updateAction model action =
                 zoom_level =
                     MapExtent.viewportToZoomLevel viewport
 
-                tiles =
+                xys =
                     MapExtent.tiles zoom_level viewport
 
                 boxes =
-                    Debug.log "boxes"
-                        (List.map
-                            (\t ->
-                                MapExtent.toBox zoom_level t
-                            )
-                            tiles
+                    List.map
+                        (\t ->
+                            MapExtent.toBox zoom_level t
                         )
-
-                bounding_box =
-                    viewport
-                        |> Viewport.map toWGS84
-                        |> MapExtent.viewportToBox
+                        xys
 
                 cmd =
                     Cmd.batch
-                        [ getNaturalEarthFeature
-                            model.baseURL
-                            NaturalEarthFeature.Coastline
-                            bounding_box
-                        , getNaturalEarthFeature
-                            model.baseURL
-                            NaturalEarthFeature.Border
-                            bounding_box
-                        , getNaturalEarthFeature
-                            model.baseURL
-                            NaturalEarthFeature.DisputedBorder
-                            bounding_box
-                        , getNaturalEarthFeature
-                            model.baseURL
-                            NaturalEarthFeature.Lake
-                            bounding_box
-                        ]
+                        (List.map
+                            (\bounding_box ->
+                                [ getNaturalEarthFeature
+                                    model.baseURL
+                                    NaturalEarthFeature.Coastline
+                                    bounding_box
+                                , getNaturalEarthFeature
+                                    model.baseURL
+                                    NaturalEarthFeature.Border
+                                    bounding_box
+                                , getNaturalEarthFeature
+                                    model.baseURL
+                                    NaturalEarthFeature.DisputedBorder
+                                    bounding_box
+                                , getNaturalEarthFeature
+                                    model.baseURL
+                                    NaturalEarthFeature.Lake
+                                    bounding_box
+                                ]
+                                    |> Cmd.batch
+                            )
+                            boxes
+                        )
             in
             ( { model
                 | zoom_level = Just zoom_level
-                , tiles = tiles
+                , tiles = xys
                 , boxes = boxes
               }
             , cmd

--- a/forest_lite/client/src/elm-app/src/Main.elm
+++ b/forest_lite/client/src/elm-app/src/Main.elm
@@ -1033,19 +1033,19 @@ updateAction model action =
                         [ getNaturalEarthFeature
                             model.baseURL
                             NaturalEarthFeature.Coastline
-                            (Just viewport)
+                            viewport
                         , getNaturalEarthFeature
                             model.baseURL
                             NaturalEarthFeature.Border
-                            (Just viewport)
+                            viewport
                         , getNaturalEarthFeature
                             model.baseURL
                             NaturalEarthFeature.DisputedBorder
-                            (Just viewport)
+                            viewport
                         , getNaturalEarthFeature
                             model.baseURL
                             NaturalEarthFeature.Lake
-                            (Just viewport)
+                            viewport
                         ]
             in
             ( { model | zoom_level = Just zoom_level }, cmd )
@@ -1142,25 +1142,20 @@ updatePoint model selectPoint =
             { model | point = Just point }
 
 
-getNaturalEarthFeature : String -> NaturalEarthFeature -> Maybe (Viewport WebMercator) -> Cmd Msg
-getNaturalEarthFeature baseURL feature map_extent =
-    case map_extent of
-        Just viewport ->
-            let
-                endpoint =
-                    NaturalEarthFeature.endpoint feature
-                        (mapViewport toWGS84 viewport)
+getNaturalEarthFeature : String -> NaturalEarthFeature -> Viewport WebMercator -> Cmd Msg
+getNaturalEarthFeature baseURL feature viewport =
+    let
+        endpoint =
+            NaturalEarthFeature.endpoint feature
+                (mapViewport toWGS84 viewport)
 
-                tagger =
-                    GotNaturalEarthFeature feature
-            in
-            Http.get
-                { url = baseURL ++ endpoint
-                , expect = Http.expectJson tagger MultiLine.decoder
-                }
-
-        Nothing ->
-            Cmd.none
+        tagger =
+            GotNaturalEarthFeature feature
+    in
+    Http.get
+        { url = baseURL ++ endpoint
+        , expect = Http.expectJson tagger MultiLine.decoder
+        }
 
 
 getDatasets : String -> Cmd Msg

--- a/forest_lite/client/src/elm-app/src/Main.elm
+++ b/forest_lite/client/src/elm-app/src/Main.elm
@@ -591,7 +591,7 @@ update msg model =
                 Ok data ->
                     let
                         cmd =
-                            SetNaturalEarthFeature feature data
+                            SetNaturalEarthFeature feature box data
                                 |> encodeAction
                                 |> sendAction
                     in
@@ -1175,6 +1175,7 @@ getNaturalEarthFeature baseURL feature box =
         endpoint =
             NaturalEarthFeature.endpoint feature box
 
+        -- Tagger should take key, e.g. Quadkey
         tagger =
             GotNaturalEarthFeature feature box
     in
@@ -1737,7 +1738,7 @@ type Action
     | SetVisible Bool
     | SetFlag Bool
     | SetLimits Float Float DatasetID DataVarLabel
-    | SetNaturalEarthFeature NaturalEarthFeature MultiLine
+    | SetNaturalEarthFeature NaturalEarthFeature BoundingBox MultiLine
     | SetCoastlineColor String
     | SetFigure Float Float Float Float
 
@@ -1775,11 +1776,12 @@ encodeAction action =
                     ]
                 )
 
-        SetNaturalEarthFeature feature data ->
+        SetNaturalEarthFeature feature box data ->
             buildAction "SET_NATURAL_EARTH_FEATURE"
                 (Json.Encode.object
                     [ ( "feature", NaturalEarthFeature.encode feature )
                     , ( "data", MultiLine.encode data )
+                    , ( "bounding_box", BoundingBox.encode box )
                     ]
                 )
 

--- a/forest_lite/client/src/elm-app/src/Main.elm
+++ b/forest_lite/client/src/elm-app/src/Main.elm
@@ -1,5 +1,6 @@
 port module Main exposing (..)
 
+import BoundingBox exposing (BoundingBox)
 import Browser
 import DataVarLabel exposing (DataVarLabel)
 import DatasetID exposing (DatasetID)
@@ -197,7 +198,7 @@ type alias Model =
     , collapsed : Dict String Bool
     , zoom_level : Maybe ZoomLevel
     , tiles : List MapExtent.XY
-    , boxes : List MapExtent.Box
+    , boxes : List BoundingBox
     }
 
 
@@ -319,7 +320,7 @@ type alias Collapsible =
 
 type Msg
     = PortReceived (Result Json.Decode.Error PortMessage)
-    | GotNaturalEarthFeature NaturalEarthFeature (Result Http.Error MultiLine)
+    | GotNaturalEarthFeature NaturalEarthFeature BoundingBox (Result Http.Error MultiLine)
     | GotDatasets (Result Http.Error (List Dataset))
     | GotDatasetDescription DatasetID (Result Http.Error DatasetDescription)
     | GotAxis DatasetID (Result Http.Error Axis)
@@ -585,7 +586,7 @@ update msg model =
                     ( model, Cmd.none )
 
         -- NATURAL EARTH FEATURE
-        GotNaturalEarthFeature feature result ->
+        GotNaturalEarthFeature feature box result ->
             case result of
                 Ok data ->
                     let
@@ -1168,14 +1169,14 @@ updatePoint model selectPoint =
             { model | point = Just point }
 
 
-getNaturalEarthFeature : String -> NaturalEarthFeature -> MapExtent.Box -> Cmd Msg
+getNaturalEarthFeature : String -> NaturalEarthFeature -> BoundingBox -> Cmd Msg
 getNaturalEarthFeature baseURL feature box =
     let
         endpoint =
             NaturalEarthFeature.endpoint feature box
 
         tagger =
-            GotNaturalEarthFeature feature
+            GotNaturalEarthFeature feature box
     in
     Http.get
         { url = baseURL ++ endpoint

--- a/forest_lite/client/src/elm-app/src/Main.elm
+++ b/forest_lite/client/src/elm-app/src/Main.elm
@@ -71,6 +71,7 @@ import MultiLine exposing (MultiLine)
 import NaturalEarthFeature exposing (NaturalEarthFeature)
 import Time
 import Viewport exposing (Viewport)
+import ZXY exposing (XY)
 import ZoomLevel exposing (ZoomLevel)
 
 
@@ -197,7 +198,7 @@ type alias Model =
     , limits : Limits
     , collapsed : Dict String Bool
     , zoom_level : Maybe ZoomLevel
-    , tiles : List MapExtent.XY
+    , tiles : List ZXY.XY
     , boxes : List BoundingBox
     }
 
@@ -1443,7 +1444,7 @@ viewZoomLevel zoom_level =
             div [] [ text "Zoom level not set" ]
 
 
-viewTiles : List MapExtent.XY -> Html Msg
+viewTiles : List ZXY.XY -> Html Msg
 viewTiles tiles =
     div
         [ style "margin-left" "0.5em"

--- a/forest_lite/client/src/elm-app/src/Main.elm
+++ b/forest_lite/client/src/elm-app/src/Main.elm
@@ -194,7 +194,6 @@ type alias Model =
     , coastlines : Bool
     , coastlines_color : String
     , limits : Limits
-    , map_extent : Maybe (Viewport WebMercator)
     , collapsed : Dict String Bool
     }
 
@@ -383,7 +382,6 @@ init flags =
                 , data_source = Undefined
                 , origin = DataSource
                 }
-            , map_extent = Nothing
             , collapsed =
                 Dict.empty
             }
@@ -397,18 +395,6 @@ init flags =
                 cmd =
                     Cmd.batch
                         [ getDatasets baseURL
-                        , getNaturalEarthFeature baseURL
-                            NaturalEarthFeature.Coastline
-                            default.map_extent
-                        , getNaturalEarthFeature baseURL
-                            NaturalEarthFeature.Border
-                            default.map_extent
-                        , getNaturalEarthFeature baseURL
-                            NaturalEarthFeature.DisputedBorder
-                            default.map_extent
-                        , getNaturalEarthFeature baseURL
-                            NaturalEarthFeature.Lake
-                            default.map_extent
                         ]
             in
             case settings.claim of
@@ -1056,7 +1042,7 @@ updateAction model action =
                             map_extent
                         ]
             in
-            ( { model | map_extent = map_extent }, cmd )
+            ( model, cmd )
 
         SetLimits low high _ _ ->
             let

--- a/forest_lite/client/src/elm-app/src/MapExtent.elm
+++ b/forest_lite/client/src/elm-app/src/MapExtent.elm
@@ -118,10 +118,18 @@ xyRange (XY x_start y_start) (XY x_end y_end) =
         ys =
             List.range y_start y_end
     in
-    List.map
-        (\f -> List.map f ys)
-        (List.map xy xs)
-        |> List.concat
+    nested xy xs ys
+
+
+{-| Application of operation on cartesian product of two lists
+
+A helper to make it easy to combine multiple combinations
+of lists into a single list using a binary operation
+
+-}
+nested : (a -> b -> c) -> List a -> List b -> List c
+nested op x y =
+    List.map (\f -> List.map f y) (List.map op x) |> List.concat
 
 
 viewportFromFloat : Float -> Float -> Float -> Float -> Viewport WebMercator

--- a/forest_lite/client/src/elm-app/src/MapExtent.elm
+++ b/forest_lite/client/src/elm-app/src/MapExtent.elm
@@ -1,20 +1,13 @@
 module MapExtent exposing (..)
 
 import Binary
+import BoundingBox exposing (BoundingBox)
 import Viewport exposing (Viewport)
 import ZoomLevel exposing (ZoomLevel)
 
 
 
 -- SLIPPY MAP
-
-
-type alias Box =
-    { minlon : Float
-    , maxlon : Float
-    , minlat : Float
-    , maxlat : Float
-    }
 
 
 type ZXY
@@ -80,14 +73,14 @@ vertexLocation z i j =
     WebMercator (x0 + x * width) (y0 - y * width)
 
 
-toBox : ZoomLevel -> XY -> Box
+toBox : ZoomLevel -> XY -> BoundingBox
 toBox level xy_index =
     xyToExtent level xy_index
         |> Viewport.map toWGS84
         |> viewportToBox
 
 
-viewportToBox : Viewport WGS84 -> Box
+viewportToBox : Viewport WGS84 -> BoundingBox
 viewportToBox (Viewport.Viewport start end) =
     { minlon = min start.longitude end.longitude
     , maxlon = max start.longitude end.longitude

--- a/forest_lite/client/src/elm-app/src/MapExtent.elm
+++ b/forest_lite/client/src/elm-app/src/MapExtent.elm
@@ -1,6 +1,7 @@
 module MapExtent exposing (..)
 
 import Binary
+import Viewport exposing (Viewport)
 import ZoomLevel exposing (ZoomLevel)
 
 
@@ -53,7 +54,7 @@ xyToString (XY x y) =
 
 xyToExtent : ZoomLevel -> XY -> Viewport WebMercator
 xyToExtent (ZoomLevel.ZoomLevel z) (XY i j) =
-    Viewport
+    Viewport.Viewport
         (vertexLocation z i j)
         (vertexLocation z (i + 1) (j + 1))
 
@@ -82,12 +83,12 @@ vertexLocation z i j =
 toBox : ZoomLevel -> XY -> Box
 toBox level xy_index =
     xyToExtent level xy_index
-        |> mapViewport toWGS84
+        |> Viewport.map toWGS84
         |> viewportToBox
 
 
 viewportToBox : Viewport WGS84 -> Box
-viewportToBox (Viewport start end) =
+viewportToBox (Viewport.Viewport start end) =
     { minlon = min start.longitude end.longitude
     , maxlon = max start.longitude end.longitude
     , minlat = min start.latitude end.latitude
@@ -96,7 +97,7 @@ viewportToBox (Viewport start end) =
 
 
 tiles : ZoomLevel -> Viewport WebMercator -> List XY
-tiles level (Viewport start end) =
+tiles level (Viewport.Viewport start end) =
     let
         -- Flip diagonal direction to satisfy assumptions
         north_west =
@@ -123,20 +124,6 @@ xyRange (XY x_start y_start) (XY x_end y_end) =
         |> List.concat
 
 
-type Viewport a
-    = Viewport a a
-
-
-mapViewport : (a -> b) -> Viewport a -> Viewport b
-mapViewport f (Viewport start end) =
-    Viewport (f start) (f end)
-
-
-startPoint : Viewport a -> a
-startPoint (Viewport start _) =
-    start
-
-
 viewportFromFloat : Float -> Float -> Float -> Float -> Viewport WebMercator
 viewportFromFloat x_start y_start x_end y_end =
     let
@@ -146,7 +133,7 @@ viewportFromFloat x_start y_start x_end y_end =
         end =
             { x = x_end, y = y_end }
     in
-    Viewport start end
+    Viewport.Viewport start end
 
 
 viewportToZoomLevel : Viewport WebMercator -> ZoomLevel
@@ -160,7 +147,7 @@ viewportToZoomLevel viewport =
 
 
 averageLength : Viewport WebMercator -> Float
-averageLength (Viewport start end) =
+averageLength (Viewport.Viewport start end) =
     sqrt ((start.x - end.x) * (start.y - end.y))
 
 

--- a/forest_lite/client/src/elm-app/src/MapExtent.elm
+++ b/forest_lite/client/src/elm-app/src/MapExtent.elm
@@ -26,18 +26,6 @@ zxyToExtent (ZXY.ZXY level point) =
     xyToExtent level point
 
 
-xyToString : XY -> String
-xyToString (ZXY.XY x y) =
-    let
-        xs =
-            String.fromInt x
-
-        ys =
-            String.fromInt y
-    in
-    "(" ++ xs ++ ", " ++ ys ++ ")"
-
-
 xyToExtent : ZoomLevel -> XY -> Viewport WebMercator
 xyToExtent (ZoomLevel.ZoomLevel z) (ZXY.XY i j) =
     Viewport.Viewport

--- a/forest_lite/client/src/elm-app/src/MapExtent.elm
+++ b/forest_lite/client/src/elm-app/src/MapExtent.elm
@@ -1,19 +1,11 @@
 module MapExtent exposing (..)
 
 import Binary
+import ZoomLevel exposing (ZoomLevel)
 
 
 
 -- SLIPPY MAP
-
-
-type ZoomLevel
-    = ZoomLevel Int
-
-
-zoomLevelToInt : ZoomLevel -> Int
-zoomLevelToInt (ZoomLevel n) =
-    n
 
 
 type ZXY
@@ -31,7 +23,7 @@ xy x y =
 
 zxy : Int -> Int -> Int -> ZXY
 zxy z x y =
-    ZXY (ZoomLevel z) (XY x y)
+    ZXY (ZoomLevel.ZoomLevel z) (XY x y)
 
 
 zxyToExtent : ZXY -> Viewport WebMercator
@@ -40,7 +32,7 @@ zxyToExtent (ZXY level point) =
 
 
 xyToExtent : ZoomLevel -> XY -> Viewport WebMercator
-xyToExtent (ZoomLevel z) (XY i j) =
+xyToExtent (ZoomLevel.ZoomLevel z) (XY i j) =
     Viewport
         (vertexLocation z i j)
         (vertexLocation z (i + 1) (j + 1))
@@ -108,14 +100,14 @@ viewportFromFloat x_start y_start x_end y_end =
     Viewport start end
 
 
-zoomLevelFromViewport : Viewport WebMercator -> ZoomLevel
-zoomLevelFromViewport viewport =
+viewportToZoomLevel : Viewport WebMercator -> ZoomLevel
+viewportToZoomLevel viewport =
     let
         maximum_length =
             2 * pi * earthRadius
     in
     ceiling (logBase 2 (maximum_length / averageLength viewport))
-        |> ZoomLevel
+        |> ZoomLevel.ZoomLevel
 
 
 averageLength : Viewport WebMercator -> Float
@@ -138,7 +130,7 @@ toXY level point =
             pi * earthRadius
 
         n =
-            zoomLevelToInt level
+            ZoomLevel.toInt level
 
         dx =
             (2 * pi * earthRadius) / toFloat (2 ^ n)
@@ -174,10 +166,10 @@ quadkeyToString (Quadkey str) =
 
 
 quadkey : ZXY -> Quadkey
-quadkey (ZXY (ZoomLevel z) (XY x y)) =
+quadkey (ZXY level (XY x y)) =
     let
         length =
-            z
+            ZoomLevel.toInt level
 
         x_ints =
             Binary.fromDecimal x

--- a/forest_lite/client/src/elm-app/src/NaturalEarthFeature.elm
+++ b/forest_lite/client/src/elm-app/src/NaturalEarthFeature.elm
@@ -2,7 +2,7 @@ module NaturalEarthFeature exposing (NaturalEarthFeature(..), encode, endpoint)
 
 import Endpoint
 import Json.Encode
-import MapExtent exposing (Viewport, WGS84, WebMercator)
+import MapExtent exposing (Box)
 import Scale
 
 
@@ -34,8 +34,8 @@ toString feature =
             "lakes"
 
 
-endpoint : NaturalEarthFeature -> Viewport WGS84 -> String
-endpoint feature map_extent =
+endpoint : NaturalEarthFeature -> Box -> String
+endpoint feature box =
     let
         path =
             Endpoint.format
@@ -43,26 +43,23 @@ endpoint feature map_extent =
                 , category feature
                 , name feature
                 ]
+
+        scale =
+            Scale.fromExtent
+                box.minlon
+                box.maxlon
+                box.minlat
+                box.maxlat
     in
-    case map_extent of
-        MapExtent.Viewport start end ->
-            let
-                scale =
-                    Scale.fromExtent
-                        start.longitude
-                        end.longitude
-                        start.latitude
-                        end.latitude
-            in
-            path
-                ++ "?"
-                ++ Endpoint.paramsToString
-                    [ ( "minlon", String.fromFloat start.longitude )
-                    , ( "maxlon", String.fromFloat end.longitude )
-                    , ( "minlat", String.fromFloat start.latitude )
-                    , ( "maxlat", String.fromFloat end.latitude )
-                    , ( "scale", Scale.toString scale )
-                    ]
+    path
+        ++ "?"
+        ++ Endpoint.paramsToString
+            [ ( "minlon", String.fromFloat box.minlon )
+            , ( "maxlon", String.fromFloat box.maxlon )
+            , ( "minlat", String.fromFloat box.minlat )
+            , ( "maxlat", String.fromFloat box.maxlat )
+            , ( "scale", Scale.toString scale )
+            ]
 
 
 category : NaturalEarthFeature -> String

--- a/forest_lite/client/src/elm-app/src/NaturalEarthFeature.elm
+++ b/forest_lite/client/src/elm-app/src/NaturalEarthFeature.elm
@@ -1,8 +1,8 @@
 module NaturalEarthFeature exposing (NaturalEarthFeature(..), encode, endpoint)
 
+import BoundingBox exposing (BoundingBox)
 import Endpoint
 import Json.Encode
-import MapExtent exposing (Box)
 import Scale
 
 
@@ -34,7 +34,7 @@ toString feature =
             "lakes"
 
 
-endpoint : NaturalEarthFeature -> Box -> String
+endpoint : NaturalEarthFeature -> BoundingBox -> String
 endpoint feature box =
     let
         path =

--- a/forest_lite/client/src/elm-app/src/Quadkey.elm
+++ b/forest_lite/client/src/elm-app/src/Quadkey.elm
@@ -1,12 +1,18 @@
-module Quadkey exposing (Quadkey, toString)
+module Quadkey exposing (Quadkey, encode, fromXY, fromZXY, toString)
 
 import Binary
+import Json.Encode
 import ZXY exposing (XY, ZXY)
-import ZoomLevel
+import ZoomLevel exposing (ZoomLevel)
 
 
 type Quadkey
     = Quadkey String
+
+
+encode : Quadkey -> Json.Encode.Value
+encode (Quadkey str) =
+    Json.Encode.string str
 
 
 toString : Quadkey -> String
@@ -14,8 +20,13 @@ toString (Quadkey str) =
     str
 
 
-quadkey : ZXY -> Quadkey
-quadkey (ZXY.ZXY level (ZXY.XY x y)) =
+fromZXY : ZXY -> Quadkey
+fromZXY (ZXY.ZXY level xy) =
+    fromXY level xy
+
+
+fromXY : ZoomLevel -> XY -> Quadkey
+fromXY level (ZXY.XY x y) =
     let
         length =
             ZoomLevel.toInt level

--- a/forest_lite/client/src/elm-app/src/Quadkey.elm
+++ b/forest_lite/client/src/elm-app/src/Quadkey.elm
@@ -1,0 +1,52 @@
+module Quadkey exposing (Quadkey, toString)
+
+import Binary
+import ZXY exposing (XY, ZXY)
+import ZoomLevel
+
+
+type Quadkey
+    = Quadkey String
+
+
+toString : Quadkey -> String
+toString (Quadkey str) =
+    str
+
+
+quadkey : ZXY -> Quadkey
+quadkey (ZXY.ZXY level (ZXY.XY x y)) =
+    let
+        length =
+            ZoomLevel.toInt level
+
+        x_ints =
+            Binary.fromDecimal x
+                |> Binary.toIntegers
+                |> zeroPad length
+
+        y_ints =
+            Binary.fromDecimal y
+                |> Binary.toIntegers
+                |> zeroPad length
+
+        base4_ints =
+            List.map2 (+) x_ints (List.map ((*) 2) y_ints)
+
+        base4_strs =
+            List.map String.fromInt base4_ints
+    in
+    Quadkey (String.join "" base4_strs)
+
+
+zeroPad : Int -> List Int -> List Int
+zeroPad length array =
+    let
+        extra =
+            length - List.length array
+    in
+    if extra > 0 then
+        List.repeat extra 0 ++ array
+
+    else
+        array

--- a/forest_lite/client/src/elm-app/src/Viewport.elm
+++ b/forest_lite/client/src/elm-app/src/Viewport.elm
@@ -1,0 +1,15 @@
+module Viewport exposing (..)
+
+
+type Viewport a
+    = Viewport a a
+
+
+map : (a -> b) -> Viewport a -> Viewport b
+map f (Viewport start end) =
+    Viewport (f start) (f end)
+
+
+getStart : Viewport a -> a
+getStart (Viewport start _) =
+    start

--- a/forest_lite/client/src/elm-app/src/ZXY.elm
+++ b/forest_lite/client/src/elm-app/src/ZXY.elm
@@ -1,4 +1,4 @@
-module ZXY exposing (XY(..), ZXY(..))
+module ZXY exposing (XY(..), ZXY(..), xyToString)
 
 import ZoomLevel exposing (ZoomLevel)
 
@@ -9,3 +9,15 @@ type ZXY
 
 type XY
     = XY Int Int
+
+
+xyToString : XY -> String
+xyToString (XY x y) =
+    let
+        xs =
+            String.fromInt x
+
+        ys =
+            String.fromInt y
+    in
+    "(" ++ xs ++ ", " ++ ys ++ ")"

--- a/forest_lite/client/src/elm-app/src/ZXY.elm
+++ b/forest_lite/client/src/elm-app/src/ZXY.elm
@@ -1,0 +1,11 @@
+module ZXY exposing (XY(..), ZXY(..))
+
+import ZoomLevel exposing (ZoomLevel)
+
+
+type ZXY
+    = ZXY ZoomLevel XY
+
+
+type XY
+    = XY Int Int

--- a/forest_lite/client/src/elm-app/src/ZoomLevel.elm
+++ b/forest_lite/client/src/elm-app/src/ZoomLevel.elm
@@ -1,0 +1,15 @@
+module ZoomLevel exposing (..)
+
+
+type ZoomLevel
+    = ZoomLevel Int
+
+
+toInt : ZoomLevel -> Int
+toInt (ZoomLevel n) =
+    n
+
+
+toString : ZoomLevel -> String
+toString (ZoomLevel n) =
+    String.fromInt n

--- a/forest_lite/client/src/elm-app/tests/Example.elm
+++ b/forest_lite/client/src/elm-app/tests/Example.elm
@@ -7,7 +7,6 @@ import MapExtent
         ( WebMercator
         , earthRadius
         , quadkey
-        , startPoint
         , toZXY
         , xy
         , xyRange
@@ -15,6 +14,7 @@ import MapExtent
         , zxyToExtent
         )
 import Test exposing (..)
+import Viewport
 import ZoomLevel exposing (ZoomLevel)
 
 
@@ -58,7 +58,7 @@ zoomLevelTests =
                         (pi * earthRadius)
 
                 viewport =
-                    MapExtent.Viewport start end
+                    Viewport.Viewport start end
             in
             MapExtent.viewportToZoomLevel viewport
                 |> Expect.equal (ZoomLevel.ZoomLevel 0)
@@ -94,7 +94,7 @@ zxyToExtentTests =
                             (-pi * earthRadius)
 
                     expect =
-                        MapExtent.Viewport start end
+                        Viewport.Viewport start end
                 in
                 zxyToExtent (zxy 0 0 0)
                     |> Expect.equal expect
@@ -110,7 +110,7 @@ zxyToExtentTests =
                         WebMercator 0 0
 
                     expect =
-                        MapExtent.Viewport start end
+                        Viewport.Viewport start end
                 in
                 zxyToExtent (zxy 1 0 0)
                     |> Expect.equal expect
@@ -128,7 +128,7 @@ zxyToExtentTests =
                             (pi * earthRadius / 2)
 
                     expect =
-                        MapExtent.Viewport start end
+                        Viewport.Viewport start end
                 in
                 zxyToExtent (zxy 2 0 0)
                     |> Expect.equal expect
@@ -146,7 +146,7 @@ zxyToExtentTests =
                             (pi * earthRadius / 2)
 
                     expect =
-                        MapExtent.Viewport start end
+                        Viewport.Viewport start end
                 in
                 zxyToExtent (zxy 2 1 0)
                     |> Expect.equal expect
@@ -162,7 +162,7 @@ toZXYTests =
                     zxy 2 1 2
 
                 point =
-                    zxyToExtent tile |> startPoint
+                    zxyToExtent tile |> Viewport.getStart
             in
             toZXY (ZoomLevel.ZoomLevel 2) point
                 |> Expect.equal tile

--- a/forest_lite/client/src/elm-app/tests/Example.elm
+++ b/forest_lite/client/src/elm-app/tests/Example.elm
@@ -5,7 +5,6 @@ import Fuzz exposing (Fuzzer, int, intRange, list, string)
 import MapExtent
     exposing
         ( WebMercator
-        , ZoomLevel
         , earthRadius
         , quadkey
         , startPoint
@@ -16,6 +15,7 @@ import MapExtent
         , zxyToExtent
         )
 import Test exposing (..)
+import ZoomLevel exposing (ZoomLevel)
 
 
 quadkeyTests : Test
@@ -60,8 +60,8 @@ zoomLevelTests =
                 viewport =
                     MapExtent.Viewport start end
             in
-            MapExtent.zoomLevelFromViewport viewport
-                |> Expect.equal (MapExtent.ZoomLevel 0)
+            MapExtent.viewportToZoomLevel viewport
+                |> Expect.equal (ZoomLevel.ZoomLevel 0)
 
 
 xyTests : Test
@@ -164,5 +164,5 @@ toZXYTests =
                 point =
                     zxyToExtent tile |> startPoint
             in
-            toZXY (MapExtent.ZoomLevel 2) point
+            toZXY (ZoomLevel.ZoomLevel 2) point
                 |> Expect.equal tile


### PR DESCRIPTION
To enable client-side caching requesting coastlines in tiles instead of arbitrary map extents is more efficient