### PR TITLE
Use elm-geometry to apply bounding box to coastlines, borders and lakes

### DIFF
--- a/forest_lite/client/src/elm-app/elm.json
+++ b/forest_lite/client/src/elm-app/elm.json
@@ -14,22 +14,28 @@
             "elm/json": "1.1.3",
             "elm/regex": "1.0.0",
             "elm/time": "1.0.0",
+            "ianmackenzie/elm-geometry": "3.9.0",
+            "ianmackenzie/elm-units": "2.7.0",
             "icidasset/elm-binary": "2.1.0"
         },
         "indirect": {
             "elm/bytes": "1.0.8",
             "elm/file": "1.0.5",
+            "elm/random": "1.0.0",
             "elm/url": "1.0.0",
             "elm/virtual-dom": "1.0.2",
-            "elm-community/list-extra": "8.2.4"
+            "elm-community/list-extra": "8.2.4",
+            "ianmackenzie/elm-1d-parameter": "1.0.1",
+            "ianmackenzie/elm-float-extra": "1.1.0",
+            "ianmackenzie/elm-interval": "2.0.0",
+            "ianmackenzie/elm-triangular-mesh": "1.1.0",
+            "ianmackenzie/elm-units-interval": "2.3.0"
         }
     },
     "test-dependencies": {
         "direct": {
             "elm-explorations/test": "1.2.2"
         },
-        "indirect": {
-            "elm/random": "1.0.0"
-        }
+        "indirect": {}
     }
 }

--- a/forest_lite/client/src/elm-app/src/BoundingBox.elm
+++ b/forest_lite/client/src/elm-app/src/BoundingBox.elm
@@ -3,6 +3,8 @@ module BoundingBox exposing (BoundingBox, encode)
 import Json.Encode
 
 
+{-| Bounding box in longitude/latitude coordinates
+-}
 type alias BoundingBox =
     { minlon : Float
     , maxlon : Float

--- a/forest_lite/client/src/elm-app/src/Geometry.elm
+++ b/forest_lite/client/src/elm-app/src/Geometry.elm
@@ -1,0 +1,142 @@
+module Geometry exposing (..)
+
+import Axis2d
+import BoundingBox2d exposing (BoundingBox2d)
+import Length exposing (Meters)
+import LineSegment2d exposing (LineSegment2d)
+import MultiLine exposing (MultiLine)
+import Point2d exposing (Point2d)
+import Polyline2d exposing (Polyline2d)
+import Quantity
+
+
+{-| Clip Bokeh multilines overlapping with BoundingBox2d
+-}
+clip : BoundingBox2d Meters coordinates -> MultiLine -> MultiLine
+clip box bokeh_lines =
+    bokeh_lines
+        |> toPolyline2d
+        |> List.map (clipPolyline2d box)
+        |> List.concat
+        |> fromPolyline2d
+
+
+{-| Remove line segments completely outside bounding box
+-}
+clipPolyline2d :
+    BoundingBox2d Meters coordinates
+    -> Polyline2d Meters coordinates
+    -> List (Polyline2d Meters coordinates)
+clipPolyline2d box polyline =
+    polyline
+        |> Polyline2d.segments
+        |> cut (overlapsWith box)
+        |> List.map toVertices
+        |> List.map Polyline2d.fromVertices
+
+
+toVertices : List (LineSegment2d units coords) -> List (Point2d units coords)
+toVertices segments =
+    case segments of
+        [] ->
+            []
+
+        head :: _ ->
+            LineSegment2d.startPoint head
+                :: (segments
+                        |> List.map LineSegment2d.endPoint
+                   )
+
+
+{-| Check segment and box overlap
+-}
+overlapsWith :
+    BoundingBox2d units coordinates
+    -> LineSegment2d units coordinates
+    -> Bool
+overlapsWith box segment =
+    let
+        start =
+            LineSegment2d.startPoint segment
+
+        end =
+            LineSegment2d.endPoint segment
+    in
+    BoundingBox2d.contains start box
+        || BoundingBox2d.contains end box
+
+
+{-| Convert from Bokeh Multiline to elm-geometry Polyline2d
+-}
+toPolyline2d : MultiLine -> List (Polyline2d Meters coordinates)
+toPolyline2d { xs, ys } =
+    List.map2 converter xs ys
+
+
+converter : List Float -> List Float -> Polyline2d Meters coordinates
+converter x y =
+    let
+        points =
+            List.map2 Point2d.meters x y
+    in
+    Polyline2d.fromVertices points
+
+
+fromPolyline2d : List (Polyline2d Meters coordinates) -> MultiLine
+fromPolyline2d polylines =
+    let
+        -- NOTE conversion to raw Floats loses unit information
+        xs =
+            polylines
+                |> List.map Polyline2d.vertices
+                |> List.map
+                    (List.map
+                        (Point2d.xCoordinate
+                            >> Quantity.unwrap
+                        )
+                    )
+
+        ys =
+            polylines
+                |> List.map Polyline2d.vertices
+                |> List.map
+                    (List.map
+                        (Point2d.yCoordinate
+                            >> Quantity.unwrap
+                        )
+                    )
+    in
+    { xs = xs, ys = ys }
+
+
+{-| Cut list into smaller lists given a criteria
+-}
+cut : (a -> Bool) -> List a -> List (List a)
+cut f items =
+    cutHelper f (List.reverse items) [] []
+
+
+cutHelper : (a -> Bool) -> List a -> List (List a) -> List a -> List (List a)
+cutHelper f items result group =
+    case items of
+        [] ->
+            case group of
+                [] ->
+                    result
+
+                _ ->
+                    group :: result
+
+        x :: xs ->
+            if f x then
+                -- APPEND X TO GROUP
+                cutHelper f xs result (x :: group)
+
+            else
+                -- SKIP X AND RESET GROUP
+                case group of
+                    [] ->
+                        cutHelper f xs result []
+
+                    _ ->
+                        cutHelper f xs (group :: result) []

--- a/forest_lite/client/src/elm-app/src/MapExtent.elm
+++ b/forest_lite/client/src/elm-app/src/MapExtent.elm
@@ -3,6 +3,7 @@ module MapExtent exposing (..)
 import BoundingBox exposing (BoundingBox)
 import Quadkey exposing (Quadkey)
 import Viewport exposing (Viewport)
+import WebMercator exposing (WebMercator)
 import ZXY exposing (XY, ZXY)
 import ZoomLevel exposing (ZoomLevel)
 
@@ -177,12 +178,6 @@ bucketIndex x0 dx x =
 type alias WGS84 =
     { longitude : Float
     , latitude : Float
-    }
-
-
-type alias WebMercator =
-    { x : Float
-    , y : Float
     }
 
 

--- a/forest_lite/client/src/elm-app/src/Viewport.elm
+++ b/forest_lite/client/src/elm-app/src/Viewport.elm
@@ -13,3 +13,8 @@ map f (Viewport start end) =
 getStart : Viewport a -> a
 getStart (Viewport start _) =
     start
+
+
+getEnd : Viewport a -> a
+getEnd (Viewport _ end) =
+    end

--- a/forest_lite/client/src/elm-app/src/WebMercator.elm
+++ b/forest_lite/client/src/elm-app/src/WebMercator.elm
@@ -1,0 +1,30 @@
+module WebMercator exposing (WebMercator, toBoundingBox2d)
+
+import BoundingBox2d exposing (BoundingBox2d)
+import Length exposing (Meters, meters)
+import Viewport exposing (Viewport)
+
+
+type alias WebMercator =
+    { x : Float
+    , y : Float
+    }
+
+
+{-| BoundingBox2d in WebMercator coordinates
+-}
+toBoundingBox2d : Viewport WebMercator -> BoundingBox2d Meters coordinates
+toBoundingBox2d viewport =
+    let
+        start =
+            Viewport.getStart viewport
+
+        end =
+            Viewport.getEnd viewport
+    in
+    BoundingBox2d.fromExtrema
+        { minX = meters (min start.x end.x)
+        , maxX = meters (max start.x end.x)
+        , minY = meters (min start.y end.y)
+        , maxY = meters (max start.y end.y)
+        }

--- a/forest_lite/client/src/elm-app/tests/BoundingBoxTests.elm
+++ b/forest_lite/client/src/elm-app/tests/BoundingBoxTests.elm
@@ -1,0 +1,39 @@
+module BoundingBoxTests exposing (..)
+
+import BoundingBox2d
+import Expect exposing (Expectation, FloatingPointTolerance(..))
+import Length exposing (meters)
+import MapExtent exposing (earthRadius)
+import Quadkey
+import Test exposing (..)
+import WebMercator exposing (toBoundingBox2d)
+
+
+{-| Convert from BoundingBox to elm-geometry BoundingBox2d
+-}
+boundingBoxTests : Test
+boundingBoxTests =
+    test "toBoundingBox2d" <|
+        \_ ->
+            let
+                quadkey =
+                    Quadkey.fromString "1"
+
+                z =
+                    Quadkey.toZoomLevel quadkey
+
+                xy =
+                    Quadkey.toXY quadkey
+
+                viewport =
+                    MapExtent.xyToExtent z xy
+            in
+            toBoundingBox2d viewport
+                |> Expect.equal
+                    (BoundingBox2d.fromExtrema
+                        { minX = meters 0
+                        , maxX = meters (earthRadius * pi)
+                        , minY = meters 0
+                        , maxY = meters (earthRadius * pi)
+                        }
+                    )

--- a/forest_lite/client/src/elm-app/tests/Example.elm
+++ b/forest_lite/client/src/elm-app/tests/Example.elm
@@ -4,8 +4,7 @@ import Expect exposing (Expectation)
 import Fuzz exposing (Fuzzer, int, intRange, list, string)
 import MapExtent
     exposing
-        ( WebMercator
-        , earthRadius
+        ( earthRadius
         , toZXY
         , xy
         , xyRange
@@ -15,6 +14,7 @@ import MapExtent
 import Quadkey exposing (Quadkey)
 import Test exposing (..)
 import Viewport
+import WebMercator exposing (WebMercator)
 import ZoomLevel exposing (ZoomLevel)
 
 

--- a/forest_lite/client/src/elm-app/tests/MultilineTests.elm
+++ b/forest_lite/client/src/elm-app/tests/MultilineTests.elm
@@ -1,0 +1,244 @@
+module MultilineTests exposing (..)
+
+import Angle
+import Axis2d
+import BoundingBox2d exposing (BoundingBox2d)
+import Direction2d
+import Expect
+    exposing
+        ( Expectation
+        , FloatingPointTolerance(..)
+        )
+import Geometry exposing (overlapsWith, toPolyline2d)
+import Length exposing (Meters)
+import LineSegment2d exposing (LineSegment2d)
+import Point2d
+import Polyline2d exposing (Polyline2d)
+import Test exposing (..)
+
+
+{-| Learning tests to understand elm-units
+-}
+angleTests : Test
+angleTests =
+    test "inRadians" <|
+        \_ ->
+            let
+                angle =
+                    Angle.degrees 180
+            in
+            angle
+                |> Angle.inRadians
+                |> Expect.within (Absolute 1.0e-6) pi
+
+
+{-| Learning tests to understand elm-geometry
+-}
+elmGeometryTests : Test
+elmGeometryTests =
+    describe "elm-geometry"
+        [ test "intersectionWithAxis inside segment" <|
+            \_ ->
+                let
+                    start =
+                        Point2d.meters 0 0
+
+                    end =
+                        Point2d.meters 0 1
+
+                    x =
+                        0.5
+
+                    axis =
+                        Axis2d.through
+                            (Point2d.meters 0 x)
+                            (Direction2d.degrees 0)
+
+                    segment =
+                        LineSegment2d.from start end
+                in
+                segment
+                    |> LineSegment2d.intersectionWithAxis axis
+                    |> Expect.equal (Just (Point2d.meters 0 x))
+        , test "intersectionWithAxis outside segment" <|
+            \_ ->
+                let
+                    start =
+                        Point2d.meters 0 0
+
+                    end =
+                        Point2d.meters 0 1
+
+                    axis =
+                        Axis2d.through
+                            (Point2d.meters 0 1.1)
+                            (Direction2d.degrees 0)
+
+                    segment =
+                        LineSegment2d.from start end
+                in
+                segment
+                    |> LineSegment2d.intersectionWithAxis axis
+                    |> Expect.equal Nothing
+        , test "BoundingBox contains point" <|
+            \_ ->
+                let
+                    box =
+                        BoundingBox2d.fromExtrema
+                            { minX = Length.meters 0
+                            , maxX = Length.meters 1
+                            , minY = Length.meters 0
+                            , maxY = Length.meters 1
+                            }
+
+                    point =
+                        Point2d.meters 0.5 0.5
+                in
+                BoundingBox2d.contains point box
+                    |> Expect.equal True
+        , test "BoundingBox overlaps segment" <|
+            \_ ->
+                let
+                    box =
+                        BoundingBox2d.fromExtrema
+                            { minX = Length.meters 0
+                            , maxX = Length.meters 1
+                            , minY = Length.meters 0
+                            , maxY = Length.meters 1
+                            }
+
+                    segment =
+                        LineSegment2d.from
+                            (Point2d.meters 0.5 0.5)
+                            (Point2d.meters 1.5 0.5)
+                in
+                overlapsWith box segment
+                    |> Expect.equal True
+        , test "Polyline2d segments" <|
+            \_ ->
+                let
+                    points =
+                        Polyline2d.fromVertices
+                            [ Point2d.meters 0 0
+                            , Point2d.meters 1 0
+                            , Point2d.meters 2 0
+                            ]
+                in
+                points
+                    |> Polyline2d.segments
+                    |> Expect.equal
+                        [ LineSegment2d.from
+                            (Point2d.meters 0 0)
+                            (Point2d.meters 1 0)
+                        , LineSegment2d.from
+                            (Point2d.meters 1 0)
+                            (Point2d.meters 2 0)
+                        ]
+        , test "Polyline2d intersectWithAxis" <|
+            \_ ->
+                let
+                    points =
+                        Polyline2d.fromVertices
+                            [ Point2d.meters 0 0
+                            , Point2d.meters 1 0
+                            , Point2d.meters 2 0
+                            ]
+
+                    x =
+                        1.9
+
+                    axis =
+                        Axis2d.through
+                            (Point2d.meters x 0)
+                            (Direction2d.degrees 90)
+
+                    intersection =
+                        LineSegment2d.intersectionWithAxis axis
+                in
+                points
+                    |> Polyline2d.segments
+                    |> List.map intersection
+                    |> Expect.equal
+                        [ Nothing
+                        , Just (Point2d.meters x 0)
+                        ]
+        ]
+
+
+{-| Conversion from Bokeh format to elm-geometry and back
+-}
+conversionTests : Test
+conversionTests =
+    describe "MultiLine format conversion"
+        [ test "toPolyline2d" <|
+            \_ ->
+                let
+                    lines =
+                        { xs = [ [ 1, 2, 3 ], [ 4, 5 ] ]
+                        , ys = [ [ 6, 7, 8 ], [ 9, 10 ] ]
+                        }
+                in
+                lines
+                    |> toPolyline2d
+                    |> Expect.equal
+                        [ Polyline2d.fromVertices
+                            [ Point2d.meters 1 6
+                            , Point2d.meters 2 7
+                            , Point2d.meters 3 8
+                            ]
+                        , Polyline2d.fromVertices
+                            [ Point2d.meters 4 9
+                            , Point2d.meters 5 10
+                            ]
+                        ]
+        , test "List.map Polyline2d.segments" <|
+            \_ ->
+                let
+                    lines =
+                        { xs = [ [ 1, 2, 3 ], [ 4, 5 ] ]
+                        , ys = [ [ 1, 2, 3 ], [ 4, 5 ] ]
+                        }
+
+                    box =
+                        BoundingBox2d.fromExtrema
+                            { minX = Length.meters 2.1
+                            , maxX = Length.meters 3.9
+                            , minY = Length.meters 2.1
+                            , maxY = Length.meters 3.9
+                            }
+                in
+                lines
+                    |> Geometry.clip box
+                    |> Expect.equal
+                        { xs =
+                            [ [ 2, 3 ]
+                            , []
+                            ]
+                        , ys =
+                            [ [ 2, 3 ]
+                            , []
+                            ]
+                        }
+        ]
+
+
+cutTests : Test
+cutTests =
+    describe "cut"
+        [ test "given always True" <|
+            \_ ->
+                Geometry.cut (\x -> True) [ 1, 2, 3 ]
+                    |> Expect.equal [ [ 1, 2, 3 ] ]
+        , test "given always False" <|
+            \_ ->
+                Geometry.cut (\x -> False) [ 1, 2, 3 ]
+                    |> Expect.equal []
+        , test "given isEven" <|
+            \_ ->
+                let
+                    isEven x =
+                        modBy 2 x == 0
+                in
+                Geometry.cut isEven [ 1, 2, 3, 4 ]
+                    |> Expect.equal [ [ 2 ], [ 4 ] ]
+        ]

--- a/forest_lite/client/src/elm-app/tests/MultilineTests.elm
+++ b/forest_lite/client/src/elm-app/tests/MultilineTests.elm
@@ -212,11 +212,9 @@ conversionTests =
                     |> Expect.equal
                         { xs =
                             [ [ 2, 3 ]
-                            , []
                             ]
                         , ys =
                             [ [ 2, 3 ]
-                            , []
                             ]
                         }
         ]


### PR DESCRIPTION
- Use existing Elm libraries to make pre-processing coastlines into tiles more efficient to reduce rendering and cache overheads