### PR TITLE
Use specific zoom levels for natural earth features

### DIFF
--- a/forest_lite/client/src/elm-app/src/Main.elm
+++ b/forest_lite/client/src/elm-app/src/Main.elm
@@ -66,6 +66,7 @@ import MapExtent
 import MultiLine exposing (MultiLine)
 import NaturalEarthFeature exposing (NaturalEarthFeature)
 import Quadkey exposing (Quadkey)
+import Scale exposing (Scale)
 import Time
 import Viewport exposing (Viewport)
 import WebMercator
@@ -1052,6 +1053,7 @@ updateAction model action =
 
                 zoom_level =
                     MapExtent.viewportToZoomLevel viewport
+                        |> Scale.truncateZoomLevel
 
                 xys =
                     MapExtent.tiles zoom_level viewport
@@ -1083,8 +1085,11 @@ updateAction model action =
                 bounding_box =
                     MapExtent.toBox z xy
 
+                scale =
+                    Scale.fromZoomLevel z
+
                 cmd =
-                    getNaturalEarthFeature model.baseURL feature bounding_box z quadkey
+                    getNaturalEarthFeature model.baseURL feature bounding_box scale quadkey
             in
             ( model, cmd )
 
@@ -1180,11 +1185,11 @@ updatePoint model selectPoint =
             { model | point = Just point }
 
 
-getNaturalEarthFeature : String -> NaturalEarthFeature -> BoundingBox -> ZoomLevel -> Quadkey -> Cmd Msg
-getNaturalEarthFeature baseURL feature box z quadkey =
+getNaturalEarthFeature : String -> NaturalEarthFeature -> BoundingBox -> Scale -> Quadkey -> Cmd Msg
+getNaturalEarthFeature baseURL feature box scale quadkey =
     let
         endpoint =
-            NaturalEarthFeature.endpoint feature box z
+            NaturalEarthFeature.endpoint feature box scale
 
         -- Tagger should take key, e.g. Quadkey
         tagger =

--- a/forest_lite/client/src/elm-app/src/NaturalEarthFeature.elm
+++ b/forest_lite/client/src/elm-app/src/NaturalEarthFeature.elm
@@ -1,11 +1,15 @@
-module NaturalEarthFeature exposing (NaturalEarthFeature(..), decoder, encode, endpoint)
+module NaturalEarthFeature exposing
+    ( NaturalEarthFeature(..)
+    , decoder
+    , encode
+    , endpoint
+    )
 
 import BoundingBox exposing (BoundingBox)
 import Endpoint
 import Json.Decode exposing (Decoder)
 import Json.Encode
-import Scale
-import ZoomLevel exposing (ZoomLevel)
+import Scale exposing (Scale)
 
 
 type NaturalEarthFeature
@@ -59,8 +63,8 @@ toString feature =
             "lakes"
 
 
-endpoint : NaturalEarthFeature -> BoundingBox -> ZoomLevel -> String
-endpoint feature box zoom_level =
+endpoint : NaturalEarthFeature -> BoundingBox -> Scale -> String
+endpoint feature box scale =
     let
         path =
             Endpoint.format
@@ -68,10 +72,6 @@ endpoint feature box zoom_level =
                 , category feature
                 , name feature
                 ]
-
-        scale =
-            Scale.fromZoomLevel
-                zoom_level
     in
     path
         ++ "?"

--- a/forest_lite/client/src/elm-app/src/Scale.elm
+++ b/forest_lite/client/src/elm-app/src/Scale.elm
@@ -1,4 +1,11 @@
-module Scale exposing (fromExtent, fromZoomLevel, toString)
+module Scale exposing
+    ( Scale
+    , fromExtent
+    , fromZoomLevel
+    , toString
+    , toZoomLevel
+    , truncateZoomLevel
+    )
 
 import ZoomLevel exposing (ZoomLevel)
 
@@ -21,6 +28,15 @@ fromExtent x_start x_end y_start y_end =
         Large
 
 
+{-| Truncate ZoomLevel to minimum level that satisfies scale
+-}
+truncateZoomLevel : ZoomLevel -> ZoomLevel
+truncateZoomLevel level =
+    level
+        |> fromZoomLevel
+        |> toZoomLevel
+
+
 fromZoomLevel : ZoomLevel -> Scale
 fromZoomLevel level =
     let
@@ -35,6 +51,21 @@ fromZoomLevel level =
 
     else
         Large
+
+
+{-| Minimum ZoomLevel that satisfies length scale
+-}
+toZoomLevel : Scale -> ZoomLevel
+toZoomLevel scale =
+    case scale of
+        Small ->
+            ZoomLevel.ZoomLevel 5
+
+        Medium ->
+            ZoomLevel.ZoomLevel 3
+
+        Large ->
+            ZoomLevel.ZoomLevel 1
 
 
 toString : Scale -> String

--- a/forest_lite/client/src/elm-app/tests/ScaleTests.elm
+++ b/forest_lite/client/src/elm-app/tests/ScaleTests.elm
@@ -1,0 +1,27 @@
+module ScaleTests exposing (..)
+
+import Expect exposing (Expectation)
+import Scale exposing (truncateZoomLevel)
+import Test exposing (..)
+import ZoomLevel exposing (ZoomLevel)
+
+
+scaleTests : Test
+scaleTests =
+    describe "truncateZoomLevel"
+        [ test "given 2 returns 1" <|
+            \_ ->
+                ZoomLevel.ZoomLevel 2
+                    |> truncateZoomLevel
+                    |> Expect.equal (ZoomLevel.ZoomLevel 1)
+        , test "given 4 returns 3" <|
+            \_ ->
+                ZoomLevel.ZoomLevel 4
+                    |> truncateZoomLevel
+                    |> Expect.equal (ZoomLevel.ZoomLevel 3)
+        , test "given 6 returns 5" <|
+            \_ ->
+                ZoomLevel.ZoomLevel 6
+                    |> truncateZoomLevel
+                    |> Expect.equal (ZoomLevel.ZoomLevel 5)
+        ]


### PR DESCRIPTION
- Minify usage of IndexedDB by mapping ZoomLevel to resolution 1 to 1