### PR TITLE
Refactor decode query str

### DIFF
--- a/forest_lite/server/drivers/iris.py
+++ b/forest_lite/server/drivers/iris.py
@@ -1,4 +1,5 @@
 """Support for iris loaded data"""
+import json
 import datetime as dt
 import numpy as np
 import iris
@@ -55,6 +56,7 @@ def tilable(settings, data_var, query=None):
             lons = cube.coord(name)[:].points
 
     # Constrain cube
+    query = json.loads(query)
     dims = {key: value for key, value in query.items()
             if key not in ["grid_latitude", "grid_longitude"]}
     kwargs = {}

--- a/forest_lite/server/drivers/nearcast.py
+++ b/forest_lite/server/drivers/nearcast.py
@@ -1,6 +1,7 @@
 """
 Nearcast driver
 """
+import json
 from enum import Enum
 import datetime as dt
 import numpy as np
@@ -125,8 +126,8 @@ def nearcast_points(settings: Settings, data_var: str, dim_name: str,
     if isinstance(settings, dict):
         settings = Settings(**settings)
 
-    if isinstance(query, dict):
-        query = Query(**query)
+    if isinstance(query, str):
+        query = Query(**json.loads(query))
 
     file_names = get_file_names(settings.pattern)
 
@@ -171,8 +172,8 @@ def nearcast_points(settings: Settings, data_var: str, dim_name: str,
 
 @driver.override("tilable")
 def nearcast_tilable(settings, data_var, query: TileQuery = None):
-    if isinstance(query, dict):
-        query = TileQuery(**query)
+    if isinstance(query, str):
+        query = TileQuery(**json.loads(query))
 
     file_names = get_file_names(settings["pattern"])
     timestamp_s = query.time.timestamp()

--- a/forest_lite/server/drivers/proxy.py
+++ b/forest_lite/server/drivers/proxy.py
@@ -2,7 +2,6 @@
 Map FOREST-Lite REST API to source API
 """
 import aiohttp
-import json
 import urllib.parse
 from pydantic import BaseModel
 from forest_lite.server.drivers.base import BaseDriver
@@ -38,7 +37,6 @@ async def data_tile(settings_dict, data_var, z, x, y, query=None):
     dataset_id = Settings(**settings_dict).dataset_id
     endpoint = f"{url}/datasets/{dataset_id}/{data_var}/tiles/{z}/{x}/{y}"
     if query is not None:
-        query = urllib.parse.quote(json.dumps(query))
         endpoint = f"{endpoint}?query={query}"
     return await http_get(endpoint)
 

--- a/forest_lite/server/drivers/proxy.py
+++ b/forest_lite/server/drivers/proxy.py
@@ -2,7 +2,6 @@
 Map FOREST-Lite REST API to source API
 """
 import aiohttp
-import urllib.parse
 from pydantic import BaseModel
 from forest_lite.server.drivers.base import BaseDriver
 

--- a/forest_lite/server/drivers/xarray_h5netcdf.py
+++ b/forest_lite/server/drivers/xarray_h5netcdf.py
@@ -1,5 +1,6 @@
 import os
 import glob
+import json
 import xarray
 from forest_lite.server.drivers.base import BaseDriver
 from forest_lite.server.lib import core
@@ -75,9 +76,6 @@ def points(settings, data_var, dim_name, query=None):
 
 
 def get_data_tile(pattern, engine, data_var, z, x, y, query=None):
-    if query is not None:
-        # Hashable query
-        query = frozenset(query.items())
     path = core.get_path(pattern)
     return _data_tile(path, engine, data_var, z, x, y, query)
 
@@ -109,7 +107,7 @@ def _data_tile(path, engine, data_var, z, x, y, query):
         if query is None:
             array = nc[data_var]
         else:
-            idx = dict(query)
+            idx = json.loads(query)
 
             # Map miliseconds to datetime
             idx = { key: convert_ms(key, value) for key, value in idx.items() }

--- a/forest_lite/server/routers/datasets.py
+++ b/forest_lite/server/routers/datasets.py
@@ -6,7 +6,6 @@ from bokeh.core.json_encoder import serialize_json
 import numpy as np
 from forest_lite.server import config
 from typing import Optional
-import json
 import urllib.parse
 from forest_lite.server.config import Settings, get_settings
 
@@ -60,9 +59,6 @@ async def data_tiles(dataset_id: int,
                      query: Optional[str] = None,
                      settings: config.Settings = Depends(config.get_settings)):
     """GET data tile from dataset at particular time"""
-    # TODO: Stop decoding the query str
-    if query is not None:
-        query = json.loads(query)
     dataset = by_id(settings.datasets, dataset_id)
     driver = drivers.from_spec(dataset.driver)
     settings = dataset.driver.settings
@@ -183,8 +179,6 @@ async def axis(dataset_id: int,
                query: Optional[str] = None,
                settings: config.Settings = Depends(config.get_settings)):
     """GET dimension values related to particular data_var"""
-    if query is not None:
-        query = json.loads(query)
     dataset = by_id(settings.datasets, dataset_id)
     driver = drivers.from_spec(dataset.driver)
     settings = dataset.driver.settings

--- a/forest_lite/test/test_drivers_iris.py
+++ b/forest_lite/test/test_drivers_iris.py
@@ -1,3 +1,4 @@
+import json
 import datetime as dt
 import os
 import iris
@@ -51,12 +52,12 @@ def test_driver_tilable(sample_file, time):
     settings = {"pattern": sample_file}
     data_var = "relative_humidity"
     pressure = 1000
-    query = {
+    query = json.dumps({
         "time": time,
         "pressure": pressure,
         "forecast_reference_time": time,
         "forecast_period": 0
-    }
+    })
     actual = driver.tilable(settings, data_var, query=query)
     assert actual["values"].shape == (8, 9)
 

--- a/forest_lite/test/test_drivers_nearcast.py
+++ b/forest_lite/test/test_drivers_nearcast.py
@@ -1,4 +1,5 @@
 import pygrib
+import json
 import os
 import pytz
 import datetime as dt
@@ -77,9 +78,10 @@ def test_driver_points(settings):
 
 
 def test_driver_points_given_start_time_query():
+    # query comes from REST endpoint is datetime support relevant?
     settings = nearcast.Settings(pattern=os.path.join(SAMPLE_DIR, "*GRIB2"))
     start_date = dt.datetime(2021, 1, 21, 0, 30, tzinfo=UTC)
-    query = {nearcast.DIMENSION.start_time.name: start_date}
+    query = json.dumps({nearcast.DIMENSION.start_time.name: str(start_date)})
     dim_name = nearcast.DIMENSION.time.name
     data_var = "U component of wind"
     response = driver.points(settings, data_var, dim_name, query=query)
@@ -91,9 +93,9 @@ def test_driver_points_given_start_time_query():
 def test_driver_tilable(settings, data_var):
     time = dt.datetime(2019, 12, 16, 14, 30, tzinfo=UTC)
     timestamp_ms = time.timestamp() * 1000
-    query = {
+    query = json.dumps({
         "time": timestamp_ms
-    }
+    })
     actual = driver.tilable(settings, data_var, query=query)
     expected = (300,)
     assert actual["latitude"].shape == expected
@@ -184,13 +186,13 @@ def test_tilable_given_real_file(real_file):
     time = dt.datetime(2021, 1, 25, 0, 0, 0, tzinfo=UTC)
     timestamp_ms = time.timestamp() * 1000
     level = 699999988
-    query = {
+    query = json.dumps({
         "start_time": 0,
         "time": timestamp_ms,
         "level": level
-    }
-    json = driver.tilable(settings, data_var, query=query)
-    actual = json["values"]
+    })
+    obj = driver.tilable(settings, data_var, query=query)
+    actual = obj["values"]
     expected = [1, 2, 3]
     assert actual[0, 0] == -7.644691467285156e-1
     # assert_array_almost_equal(actual, expected)


### PR DESCRIPTION
- Let driver determine how to use query str
- Proxy driver uses it to forward GET requests
- Xarray driver uses it to call `data_array.sel(**args)`